### PR TITLE
add methods renameFamily and forceShorterZoneNames

### DIFF
--- a/src/treelab/cgns/base.py
+++ b/src/treelab/cgns/base.py
@@ -21,6 +21,7 @@ Implements class **Base**, which inherits from :py:class:`Node`
 21/12/2021 - L. Bernardos - first creation
 '''
 import numpy as np
+from fnmatch import fnmatch
 from .. import misc as m
 from .node import Node
 from .zone import Zone
@@ -145,3 +146,132 @@ class Base(Node):
             types.update(zone.getElementsTypes())
         return types
     
+    def renameFamily(self, current_fam_name: str, new_fam_name: str, verbose: bool=True):
+        '''
+        Rename a Family in the tree, or all families which match a given pattern. 
+
+        Parameters
+        ----------
+        mesh : cgns.Tree
+            
+        current_fam_name : str
+            name of the family to modify, or pattern to modify. Can begin or/and end with '*', 
+            but cannot contain a '*' in the middle of the string.
+
+        new_fam_name : str
+            new name, without wildcards
+
+        verbose : bool
+            If True, print which families are renamed
+
+        Examples
+        --------
+
+        >>> mesh.renameFamily('BLADE', 'Blade')    # Rename Family BLADE to Blade
+        >>> mesh.renameFamily('BLADE*', 'Blade')   # Rename Family BLADE to Blade and BLADE_TIP to Blade_TIP
+        >>> mesh.renameFamily('*BLADE', 'Blade')   # Rename Family BLADE to Blade and rotor_BLADE to rotor_Blade
+        >>> mesh.renameFamily('*BLADE*', 'Blade')  # Rename Family BLADE to Blade and rotor_BLADE_TIP to rotor_Blade_TIP
+
+        '''
+        def update_new_fam_name(name, pattern, replacement):
+            if '*' not in pattern:
+                return replacement
+            
+            elif pattern.startswith('*') and pattern.endswith('*'):
+                search_term = pattern[1:-1]
+                new_name = name.replace(search_term, replacement)
+                return new_name
+
+            elif pattern.endswith('*'):
+                search_term = pattern[:-1]
+                new_name = replacement + name[len(search_term):]
+                return new_name
+    
+            elif pattern.startswith('*'):
+                search_term = pattern[1:]
+                new_name = name[:-len(search_term)] + replacement
+                return new_name
+
+            else:
+                raise ValueError(f"The pattern ({pattern}) cannot contain a '*' in the middle of it")
+        
+
+        if len(current_fam_name) > 2 and '*' in current_fam_name[1:-1]:
+            raise Exception(f"current_fam_name ({current_fam_name}) cannot contain wildcards '*' in the middle of the string.")
+
+        for family_node in self.group(Type='Family', Depth=1):
+            family = family_node.name()
+            if fnmatch(family, current_fam_name):
+
+                updated_new_fam_name = update_new_fam_name(family, current_fam_name, new_fam_name)
+                if verbose:
+                    print(f'Renaming Family {family} to {updated_new_fam_name}')
+
+                # change Family Name
+                if not self.get(Type='Family', Name=updated_new_fam_name, Depth=2):
+                    family_node.setName(updated_new_fam_name)  
+                else:
+                    family_node.remove()  # already a Family with the same name 
+
+                # Change also the value of all nodes FamilyName_t or AdditionalFamilyName_t related to that Family                
+                for node in self.group(Type='*FamilyName', Value=family):
+                    node.setValue(updated_new_fam_name)    
+    
+    def forceShorterZoneNames(self, max_length=32, root_name='Zone', max_number_of_figures=4, verbose=True):
+        # 32 is the max length for a node name as defined by the CGNS standard
+        # https://cgns.org/standard/SIDS/convention.html#data-structure-notation-conventions
+        assert max_length <= 32
+
+        def create_names_generators_by_family():            
+
+            assert len(root_name)+max_number_of_figures <= max_length
+
+            existing_zone_names = [z.name() for z in self.zones()]
+
+            def create_names_generator():
+                for suffix in range(1, pow(10, max_number_of_figures)):
+                    name = f"{root_name}{suffix}"
+                    if name not in existing_zone_names:
+                        yield name
+
+            generators = dict(default=create_names_generator())
+
+            zones_families = []
+            for z in self.zones():
+                FamilyName = z.get(Type='FamilyName', Depth=1)
+                if FamilyName:
+                    zones_families.append(FamilyName.value())
+
+            for family in zones_families:
+
+                assert len(root_name)+1+len(family)+max_number_of_figures <= max_length
+            
+                def gen(family):
+                    for suffix in range(1, pow(10, max_number_of_figures)):
+                        name = f"{root_name}_{family}{suffix}"
+                        if name not in existing_zone_names:
+                            yield name
+                generators[family] = gen(family)
+            
+            return generators
+
+        names_generators = create_names_generators_by_family()
+
+        for zone in self.zones():
+            if len(zone.name()) > max_length:
+                try:
+                    family = zone.get(Type='FamilyName', Depth=1).value()
+                except:
+                    family = 'default'
+
+                new_name = next(names_generators[family])
+                if verbose:
+                    print(f'rename zone {zone.name()} to {new_name}')
+
+                # First change all nodes values in the tree containing that zone name
+                nodes_with_zone_name_as_value = self.group(Value=zone.name(), Type='GridConnectivity1to1_t')
+                for node in nodes_with_zone_name_as_value:
+                    node.setValue(new_name)
+
+                # Finally change zone name
+                zone.setName(new_name)

--- a/src/treelab/cgns/base.py
+++ b/src/treelab/cgns/base.py
@@ -275,3 +275,9 @@ class Base(Node):
 
                 # Finally change zone name
                 zone.setName(new_name)
+
+    def removeEmptyZones(self):
+        for zone in self.zones():
+            if zone.isEmpty(): 
+                zone.remove()
+                

--- a/src/treelab/cgns/tree.py
+++ b/src/treelab/cgns/tree.py
@@ -222,3 +222,10 @@ class Tree(Node):
             types.update(base.getElementsTypes())
         return types
     
+    def renameFamily(self, current_fam_name: str, new_fam_name: str, verbose: bool=True):
+        for base in self.bases():
+            base.renameFamily(current_fam_name, new_fam_name, verbose)
+    
+    def forceShorterZoneNames(self, max_length=32, root_name='Zone', max_number_of_figures=4, verbose=True):
+        for base in self.bases():
+            base.forceShorterZoneNames(max_length, root_name, max_number_of_figures, verbose)

--- a/src/treelab/cgns/tree.py
+++ b/src/treelab/cgns/tree.py
@@ -229,3 +229,8 @@ class Tree(Node):
     def forceShorterZoneNames(self, max_length=32, root_name='Zone', max_number_of_figures=4, verbose=True):
         for base in self.bases():
             base.forceShorterZoneNames(max_length, root_name, max_number_of_figures, verbose)
+
+    def removeEmptyZones(self):
+        for base in self.bases():
+            base.removeEmptyZones()
+            

--- a/src/treelab/cgns/zone.py
+++ b/src/treelab/cgns/zone.py
@@ -605,3 +605,12 @@ class Zone(Node):
         value = np.array([[v, v - 1, 0] for v in shape_vertex], dtype=np.int32, order='F')
         self.setValue(value)
 
+    def isEmpty(self):
+        GridCoordinates = self.get(Type='GridCoordinates', Depth=1)
+        if GridCoordinates is None:
+            return True
+        coord = GridCoordinates.get(Type='DataArray')
+        if coord is None or coord.value() is None:
+            return True
+        
+        return False


### PR DESCRIPTION
Examples
-------------

```python
mesh.renameFamily('BLADE', 'Blade')    # Rename Family BLADE to Blade
mesh.renameFamily('BLADE*', 'Blade')   # Rename Family BLADE to Blade and BLADE_TIP to Blade_TIP
mesh.renameFamily('*BLADE', 'Blade')   # Rename Family BLADE to Blade and rotor_BLADE to rotor_Blade
mesh.renameFamily('*BLADE*', 'Blade')  # Rename Family BLADE to Blade and rotor_BLADE_TIP to rotor_Blade_TIP

mesh.forceShorterZoneNames(max_length=20) 
```